### PR TITLE
Support color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,49 @@ Some reasons to use **membrane.term**:
 Open a terminal window.
 
     clojure -X com.phronemophobic.membrane.term/run-term :width 90 :height 30
-    
+
 ![run-term-screenshot](terminal.gif?raw=true)
 
+If addition to `:width` and `:height`, the `run-term` function also accepts [`:color-scheme`](#color-schemes). 
 ### Run a headless terminal and take a screenshot
 
 Run a script in a headless terminal and write an image to terminal.png.
 
     clojure -X com.phronemophobic.membrane.term/run-script :path '"script.sh"'
     
-The script is passed to the terminal character by character. The script also accepts the following optional arguments:
+The script is passed to the terminal character by character. The `run-script` function also accepts the following optional arguments:
 
-`width`: number of columns for the terminal. default 90  
-`height`: number of rows for the terminal. default 30  
-`out`: filename of the image to write to. default "terminal.png"  
-`line-delay`: If you type a command like `lein repl`, the underlying program might not be ready to accept input immediately. You can specify a delay in ms to wait after each line is sent to the terminal. default 1000.  
-`final-delay`: For the same reasons as `line-delay`, there is a final delay before writing the view of the terminal. default 10000.  
+`:width`: number of columns for the terminal. default 90  
+`:height`: number of rows for the terminal. default 30  
+`:out`: filename of the image to write to. default "terminal.png"  
+`:line-delay`: If you type a command like `lein repl`, the underlying program might not be ready to accept input immediately. You can specify a delay in ms to wait after each line is sent to the terminal. default 1000.  
+`:final-delay`: For the same reasons as `line-delay`, there is a final delay before writing the view of the terminal. default 10000.  
+[`:color-scheme`](#color-schemes): choose a different color scheme.
 
 Example:
 
     clojure -X com.phronemophobic.membrane.term/run-script :path '"script.sh"' :width 120 :height 30 :final-delay 30e3 :line-delay 0 :out '"foo.jpg"'
 
+## Color Schemes
+
+There are boatloads of terminal color schemes available at [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes#screenshots).
+Review what you might like via the screenshots, then find the corresponding [`.itermcolors` file under the schemes directory](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/schemes).
+
+Use the `:color-scheme` option to specify an `.itermcolors` file, either from a copy you have downloaded:
+
+```
+clojure -X com.phronemophobic.membrane.term/run-term :width 90 :height 30 \
+  :color-scheme '"Builtin Solarized Dark.itermcolors"'
+```
+
+...or directly from the raw GitHub URL:
+
+```
+clojure -X com.phronemophobic.membrane.term/run-term :width 90 :height 30 \
+  :color-scheme '"https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/schemes/Builtin%20Solarized%20Dark.itermcolors"'
+```
+
+:point_right: Don't forget that the Clojure CLI -X syntax for strings requires `'"special quoting"'`.
 ## License
 
 Copyright © 2021 Adrian Smith

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,7 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
+        org.clojure/data.xml {:mvn/version "0.2.0-alpha6"}
+        org.clojure/data.zip {:mvn/version "1.0.0"}
         com.phronemophobic/membrane {:mvn/version "0.9.31.0-beta"
                                      ;; :local/root "../membrane2"
                                      }

--- a/src/com/phronemophobic/membrane/term/color_scheme.clj
+++ b/src/com/phronemophobic/membrane/term/color_scheme.clj
@@ -1,0 +1,81 @@
+(ns com.phronemophobic.membrane.term.color-scheme
+  (:require [clojure.data.xml :as xml]
+            [clojure.data.zip.xml :as zxml]
+            [clojure.set :as cset]
+            [clojure.java.io :as io]
+            [clojure.zip :as zip]))
+
+(def ^:private iterm-color
+  ;; iterm keys currently of interest to us, others can be added if/when we add support in membrane.term
+  {"Ansi 0 Color"        :black
+   "Ansi 1 Color"        :red
+   "Ansi 2 Color"        :green
+   "Ansi 3 Color"        :yellow
+   "Ansi 4 Color"        :blue
+   "Ansi 5 Color"        :magenta
+   "Ansi 6 Color"        :cyan
+   "Ansi 7 Color"        :white
+   "Ansi 8 Color"        :bright-black
+   "Ansi 9 Color"        :bright-red
+   "Ansi 10 Color"       :bright-green
+   "Ansi 11 Color"       :bright-yellow
+   "Ansi 12 Color"       :bright-blue
+   "Ansi 13 Color"       :bright-magenta
+   "Ansi 14 Color"       :bright-cyan
+   "Ansi 15 Color"       :bright-white
+   "Cursor Color"        :cursor
+   "Cursor Text Color"   :cursor-text
+   "Background Color"    :background
+   "Foreground Color"    :foreground})
+
+(def ^:private required-colors (cset/map-invert iterm-color))
+
+(def ^:private iterm-component
+  {"Red Component" :red
+   "Green Component" :green
+   "Blue Component" :blue
+   "Alpha Component" :alpha})
+
+(def ^:private required-components (select-keys (cset/map-invert iterm-component)
+                                                [:red :green :blue]))
+
+(defn- iterm-color->rgb [ctx zdict]
+  (let [cmap (->> (iterate #(-> % zip/right zip/right) (zip/down zdict))
+                  (take-while identity)
+                  (reduce (fn [acc z]
+                            (let [cin  (-> z zxml/text)]
+                              (if-let [ckey (get iterm-component cin)]
+                                (assoc acc ckey (-> z zip/right zxml/text Double/parseDouble))
+                                acc)))
+                          {}))
+        missing-components (apply dissoc required-components (keys cmap))]
+    (if (seq missing-components)
+      (throw (ex-info (format "%s %s is missing components: %s" (:source ctx) (pr-str (:context ctx)) (vec (vals missing-components))) {}))
+      (if (:alpha cmap)
+        ((juxt :red :green :blue :alpha) cmap)
+        ((juxt :red :green :blue) cmap)))))
+
+(defn load-scheme
+  "We currently support iTerm scheme format which is held in Apple Info.plist XML.
+
+  `source` can be whatever `clojure.java.io/reader` accepts, common usages:
+  - local path `\"./Solarized Dark.itermcolors\"` or
+  - a url `\"https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/schemes/Dracula%2B.itermcolors\"`"
+  [source]
+  (with-open [rdr (io/reader source)]
+    (let [z (-> rdr
+                (xml/parse :namespace-aware false :skip-whitespace true)
+                zip/xml-zip)
+          scheme (reduce (fn [acc z]
+                           (let [cin (-> z zxml/text)]
+                             (if-let [color-name (get iterm-color cin)]
+                               (let [rgba (->> z zip/right (iterm-color->rgb {:context cin :source source}))]
+                                 (assoc acc color-name rgba))
+                               acc)))
+                         {}
+                         (->> (iterate #(-> % zip/right zip/right) (zxml/xml1-> z :dict :key))
+                              (take-while identity)))
+          missing-keys (apply dissoc required-colors (keys scheme))]
+      (if (seq missing-keys)
+        (throw (ex-info (format "%s is missing colors: %s" source (vec (vals missing-keys))) {}))
+        scheme))))


### PR DESCRIPTION
New :color-scheme option specifies iTerm format color scheme.
See changes to README for usage.

In support of this change, scheme-able color support added for:
- :cursor (cool alpha trick turfed in favor of color scheme support)
- :cursor-text - color of text when cursor is over text
- :background - screen background
- :foreground - default text color

Also:
- noticed membrane.term was crashing when I tried
  https://github.com/sharkdp/bat. Added support for 24-bit colors.
- made some very minor clj-kondo recommended cleanups

Notes:
- Minimal, but adequate, error handling included for iterm color
  scheme loading.
- Terminal resize functionality unchanged but you'll notice that
  background color does not grow to larger size.
- I made some guesses on how to use skia, some of them were
  likely naive.

Closes #1