### PR TITLE
screenshot fn :play option is now string (was file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 ### Changed
 - Document public API [#28](https://github.com/phronmophobic/membrane.term/issues/28)
+- **Breaking** `screenshot` `:play` option was file, is now string (command line is unaffected, `--play` still references a file) [#26](https://github.com/phronmophobic/membrane.term/issues/28)
 
 ## [0.9.0] - 2021-11-30
 - Initial release to clojars

--- a/src/com/phronemophobic/membrane/term.clj
+++ b/src/com/phronemophobic/membrane/term.clj
@@ -414,7 +414,7 @@
   Terminal is not displayed and automatically exits after screenshot is written.
 
   Requires `opts` map:
-  - `:play`          Path to script to play in terminal (**required**)
+  - `:play`          Script string to play in terminal (**required**)
   - `:out`           Filename for screenshot image (default: `\"terminal.png\"`)
   - `:line-delay`    Delay in milliseconds to wait after each line in `:play` script is sent to terminal (default: `1000`)
   - `:final-delay`   Delay in milliseconds to wait after all lines in `:play` script are sent to terminal (default: `10000`)
@@ -456,7 +456,7 @@
         font (load-terminal-font toolkit font-family font-size)]
     (swap! term-state assoc
            :pty (run-pty-process width height term-state))
-    (doseq [line (string/split-lines (slurp play))]
+    (doseq [line (string/split-lines play)]
       (send-input (:pty @term-state) line)
       (send-input (:pty @term-state) "\n")
       (Thread/sleep line-delay))
@@ -471,3 +471,8 @@
     (let [^PtyProcess pty (:pty @term-state)]
       (.close (.getInputStream pty))
       (.close (.getOutputStream pty)))))
+
+(comment
+  (screenshot {:play "ls -l" :out "x.png"})
+  (screenshot {:play "ls -l\n" :out "y.png"})
+  (screenshot {:play "export PS1='$ '\nclear\nmsgcat --color=test | head -11" :out "z.png"}))

--- a/src/com/phronemophobic/membrane/term/main.clj
+++ b/src/com/phronemophobic/membrane/term/main.clj
@@ -61,6 +61,13 @@ Replace membrane.term with your appropriate Clojure tools CLI launch sequence. F
         (catch Throwable e
           {:error (format "unable to open path, %s" (ex-message e))})))))
 
+(defn- parse-play-script [v]
+  (when v
+    (let [p (parse-existing-path v)]
+      (if (:error p)
+        p
+        (slurp p)))))
+
 (defn- parse-color-scheme [v]
   (when v
     (let [p (parse-existing-path v)]
@@ -146,7 +153,7 @@ Replace membrane.term with your appropriate Clojure tools CLI launch sequence. F
                  (fn result-fn [arg-map]
                    (let [arg-map (validate-args arg-map {"--width" (int-parser-validator 1)
                                                          "--height" (int-parser-validator 1)
-                                                         "--play" parse-existing-path
+                                                         "--play" parse-play-script
                                                          "--color-scheme" parse-color-scheme
                                                          "--out" parse-image-out
                                                          "--line-delay" (int-parser-validator 0)


### PR DESCRIPTION
Command line is unaffected, --play option still specifies a file.

Contributes to #26